### PR TITLE
typespec update: aql_query returns a list of maps 

### DIFF
--- a/lib/arangox_ecto.ex
+++ b/lib/arangox_ecto.ex
@@ -49,7 +49,7 @@ defmodule ArangoXEcto do
       ]}
   """
   @spec aql_query(Ecto.Repo.t(), query(), vars(), [DBConnection.option()]) ::
-          {:ok, map()} | {:error, any()}
+          {:ok, list(map)} | {:error, any()}
   def aql_query(repo, query, vars \\ [], opts \\ []) do
     conn = gen_conn_from_repo(repo)
 


### PR DESCRIPTION
aql_query typescpec update ```map() -> list(map)```