### PR TITLE
Allow for a multiple DBs per Arango cluster

### DIFF
--- a/lib/arangox_ecto.ex
+++ b/lib/arangox_ecto.ex
@@ -49,7 +49,7 @@ defmodule ArangoXEcto do
       ]}
   """
   @spec aql_query(Ecto.Repo.t(), query(), vars(), [DBConnection.option()]) ::
-          {:ok, map()} | {:error, any()}
+          {:ok, list(map)} | {:error, any()}
   def aql_query(repo, query, vars \\ [], opts \\ []) do
     conn = gen_conn_from_repo(repo)
 

--- a/lib/mix/arangox_ecto.ex
+++ b/lib/mix/arangox_ecto.ex
@@ -43,7 +43,7 @@ defmodule Mix.ArangoXEcto do
 
   defp get_migrations_record_name() do
     config = config([])
-    db_name = Keyword.get(config, :database)
+    Keyword.get(config, :database)
   end
 
   @doc false

--- a/lib/mix/arangox_ecto.ex
+++ b/lib/mix/arangox_ecto.ex
@@ -41,11 +41,16 @@ defmodule Mix.ArangoXEcto do
     end
   end
 
+  defp get_migrations_record_name() do
+    config = config([])
+    db_name = Keyword.get(config, :database)
+  end
+
   @doc false
   def create_master_document do
     {:ok, conn} = system_db()
 
-    {:ok, _} = Arangox.post(conn, "/_api/document/_migrations", %{_key: "MASTER", migrations: []})
+    {:ok, _} = Arangox.post(conn, "/_api/document/_migrations", %{_key: get_migrations_record_name(), migrations: []})
   end
 
   @doc false
@@ -54,7 +59,7 @@ defmodule Mix.ArangoXEcto do
 
     {:ok, versions} =
       query(conn, """
-        RETURN DOCUMENT("_migrations/MASTER").migrations
+        RETURN DOCUMENT("_migrations/#{get_migrations_record_name()}").migrations
       """)
 
     versions
@@ -75,7 +80,7 @@ defmodule Mix.ArangoXEcto do
       new_versions = [version | migrated]
 
       {:ok, _} =
-        Arangox.patch(conn, "/_api/document/_migrations/MASTER", %{migrations: new_versions})
+        Arangox.patch(conn, "/_api/document/_migrations/#{get_migrations_record_name()}", %{migrations: new_versions})
 
       new_versions
     end
@@ -93,7 +98,7 @@ defmodule Mix.ArangoXEcto do
       |> List.delete(version)
 
     {:ok, _} =
-      Arangox.patch(conn, "/_api/document/_migrations/MASTER", %{migrations: new_versions})
+      Arangox.patch(conn, "/_api/document/_migrations/#{get_migrations_record_name()}", %{migrations: new_versions})
 
     new_versions
   end

--- a/lib/mix/arangox_ecto.ex
+++ b/lib/mix/arangox_ecto.ex
@@ -50,7 +50,11 @@ defmodule Mix.ArangoXEcto do
   def create_master_document do
     {:ok, conn} = system_db()
 
-    {:ok, _} = Arangox.post(conn, "/_api/document/_migrations", %{_key: get_migrations_record_name(), migrations: []})
+    case Arangox.post(conn, "/_api/document/_migrations", %{_key: get_migrations_record_name(), migrations: []}) do
+      {:ok, _} -> :ok
+      {:error, %{status: 409}} -> :ok
+      {:error, _} = err -> err
+    end
   end
 
   @doc false

--- a/lib/mix/arangox_ecto.ex
+++ b/lib/mix/arangox_ecto.ex
@@ -22,6 +22,7 @@ defmodule Mix.ArangoXEcto do
     case Arangox.post(conn, "/_api/database", %{
            name: Keyword.get(config, :database)
          }) do
+      {:ok, _} -> :ok
       {:ok, _, _} -> :ok
       {:error, %{status: status}} -> {:error, status}
     end

--- a/lib/mix/tasks/ecto.setup.arango.ex
+++ b/lib/mix/tasks/ecto.setup.arango.ex
@@ -29,6 +29,7 @@ defmodule Mix.Tasks.Ecto.Setup.Arango do
         Mix.shell().info("Setup Complete")
 
       {:error, 409} ->
+        create_master_document()
         Mix.shell().info("ArangoDB already setup for ecto")
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ArangoXEcto.MixProject do
   use Mix.Project
 
-  @version "0.7.4"
+  @version "0.7.5"
   @source_url "https://github.com/TomGrozev/arangox_ecto"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ArangoXEcto.MixProject do
   use Mix.Project
 
-  @version "0.7.2"
+  @version "0.7.4"
   @source_url "https://github.com/TomGrozev/arangox_ecto"
 
   def project do


### PR DESCRIPTION
Currently if several DBs used on a same Arango cluster it would not apply
    migrations due to the fact that migrations are stored in a single MASTER
    index of migrations, while it would be cool to have support for per DB
    configuration where migrations would be applied if different DB is used.
    
    Example might be the case when there're several environments used on a same
    cluster, aka production, stage, nightly etc.
