### PR TITLE
Use underscored module name for repo dir

### DIFF
--- a/lib/mix/arangox_ecto.ex
+++ b/lib/mix/arangox_ecto.ex
@@ -71,7 +71,15 @@ defmodule Mix.ArangoXEcto do
   @spec path_to_priv_repo(Ecto.Repo.t()) :: String.t()
   def path_to_priv_repo(repo) do
     app = Keyword.fetch!(repo.config(), :otp_app)
-    Path.join(Mix.Project.deps_paths()[app] || File.cwd!(), "priv/repo")
+
+    repo_dir =
+      repo.get_dynamic_repo()
+      |> to_string()
+      |> String.split(".")
+      |> List.last()
+      |> Macro.underscore()
+
+    Path.join([Mix.Project.deps_paths()[app] || File.cwd!(), "priv", repo_dir])
   end
 
   @doc """

--- a/test/arangox_ecto/migration_test.exs
+++ b/test/arangox_ecto/migration_test.exs
@@ -3,7 +3,7 @@ defmodule ArangoXEctoTest.MigrationTest do
   @moduletag :supported
 
   alias ArangoXEcto.Migration
-  alias ArangoXEctoTest.Repo
+  alias ArangoXEctoTest.{ArangoRepo, Repo}
 
   @test_collections [
     :something
@@ -23,6 +23,13 @@ defmodule ArangoXEctoTest.MigrationTest do
     end
 
     context
+  end
+
+  describe "mix helpers" do
+    test "repo directory name" do
+      assert Regex.match?(~r|/priv/repo$|, Mix.ArangoXEcto.path_to_priv_repo(Repo))
+      assert Regex.match?(~r|/priv/arango_repo$|, Mix.ArangoXEcto.path_to_priv_repo(ArangoRepo))
+    end
   end
 
   describe "collection/3" do

--- a/test/support/test_repo.ex
+++ b/test/support/test_repo.ex
@@ -3,3 +3,9 @@ defmodule ArangoXEctoTest.Repo do
     otp_app: :arangox_ecto,
     adapter: ArangoXEcto.Adapter
 end
+
+defmodule ArangoXEctoTest.ArangoRepo do
+  use Ecto.Repo,
+    otp_app: :arangox_ecto,
+    adapter: ArangoXEcto.Adapter
+end


### PR DESCRIPTION
### Fixes: #42
Uses the name of the Repo module to obtain the priv/repo directory name.