### PR TITLE
Correct bug preventing to use Repo.exists?

### DIFF
--- a/lib/arangox_ecto/adapter.ex
+++ b/lib/arangox_ecto/adapter.ex
@@ -16,7 +16,8 @@ defmodule ArangoXEcto.Adapter do
     :ok
   end
 
-  use Bitwise, only_operators: true
+  # import Bitwise
+  # use Bitwise, only_operators: true
 
   require Logger
 

--- a/lib/arangox_ecto/query.ex
+++ b/lib/arangox_ecto/query.ex
@@ -221,6 +221,10 @@ defmodule ArangoXEcto.Query do
     {[], values}
   end
 
+  defp get_collect_or_fields({0, 0}, _fields, _sources, _query) do
+    {[], ["1"]}
+  end
+
   defp get_collect_or_fields({c, _}, _fields, _sources, query) when c > 1,
     do: raise(Ecto.QueryError, message: "can only have one field with count", query: query)
 


### PR DESCRIPTION
Thank for your work, it is really nice to have a lib to make arango working with ecto :)

I was on the v1.0 and when I migrate on the v1.2 the functions `Ecto.Repo.exists?` and `Ecto.Changeset.unsafe_validate_unique` was not working anymore.

I made just one modification in `ArangoXEcto.Query`. It missed a pattern matching on `get_collect_or_fields` function.