### PR TITLE
Ensure custom types are loaded correctly.

### DIFF
--- a/lib/arangox_ecto/adapter.ex
+++ b/lib/arangox_ecto/adapter.ex
@@ -106,8 +106,8 @@ defmodule ArangoXEcto.Adapter do
   def loaders(:time, _type), do: [&load_time/1]
   def loaders(:utc_datetime, _type), do: [&load_utc_datetime/1]
   def loaders(:naive_datetime, _type), do: [&NaiveDateTime.from_iso8601/1]
-  def loaders(:float, _type), do: [&load_float/1]
-  def loaders(:integer, _type), do: [&load_integer/1]
+  def loaders(:float, type), do: [&load_float/1, type]
+  def loaders(:integer, type), do: [&load_integer/1, type]
   def loaders(:decimal, _type), do: [&load_decimal/1]
   def loaders(_primitive, type), do: [type]
 

--- a/test/arangox_ecto/adapter_test.exs
+++ b/test/arangox_ecto/adapter_test.exs
@@ -16,4 +16,10 @@ defmodule ArangoXEctoTest.AdapterTest do
       assert loaded_location == location
     end
   end
+
+  describe "enum type" do
+    test "custom type is loaded and dumped correctly" do
+      assert {:ok, %User{gender: :other}} = Repo.insert(%User{gender: :other})
+    end
+  end
 end

--- a/test/support/schemas.exs
+++ b/test/support/schemas.exs
@@ -7,6 +7,7 @@ defmodule ArangoXEctoTest.Integration.User do
     field(:last_name, :string)
     field(:extra, :string)
     field(:extra2, :string)
+    field(:gender, Ecto.Enum, values: [male: 0, female: 1, other: 2], default: :male)
     field(:location, ArangoXEcto.Types.GeoJSON)
 
     embeds_one(:class, ArangoXEctoTest.Integration.Class, on_replace: :delete)
@@ -28,7 +29,7 @@ defmodule ArangoXEctoTest.Integration.User do
 
   def changeset(struct, attrs) do
     struct
-    |> cast(attrs, [:first_name, :last_name, :extra, :extra2])
+    |> cast(attrs, [:first_name, :last_name, :extra, :extra2, :gender])
     |> cast_embed(:class)
     |> cast_embed(:items, with: &items_changeset/2)
     |> validate_required([:first_name, :last_name])


### PR DESCRIPTION
### Fixes: #55

The `loaders` function for primitive types must also include the type in the returned list to ensure that for custom types the load function of the corresponding module is called.

See for example the loaders implementation for MyXQL:
https://github.com/elixir-ecto/ecto_sql/blob/1acfb2a653898216d45eab85a26311a7fb0a6d6a/lib/ecto/adapters/myxql.ex#L145-L151