### PR TITLE
Correct conn argument in migration

### DIFF
--- a/lib/arangox_ecto/migration.ex
+++ b/lib/arangox_ecto/migration.ex
@@ -14,8 +14,8 @@ defmodule ArangoXEcto.Migration do
   a collection struct using the `collection/3` function. Then pass the collection struct to the
   `create/1` function. To create indexes it is a similar process using the `index/3` function.
 
-  **Order matters!!** Make sure you create collections before indexes and views, and analyzers before 
-  views if they are used. In general this is a good order to follow: 
+  **Order matters!!** Make sure you create collections before indexes and views, and analyzers before
+  views if they are used. In general this is a good order to follow:
 
       Analyzers > Collections > Indexes > Views
 
@@ -143,7 +143,7 @@ defmodule ArangoXEcto.Migration do
 
   ## Options
 
-  - `:repo` - The repo or connection to use for the migration create action 
+  - `:repo` - The repo or connection to use for the migration create action
   - `:prefix` - The prefix to use for tenant creation
 
   ## Examples
@@ -180,7 +180,7 @@ defmodule ArangoXEcto.Migration do
     case Arangox.post(
            conn,
            ArangoXEcto.__build_connection_url__(
-             repo_or_conn,
+             conn,
              "collection",
              Keyword.get(opts, :prefix)
            ),
@@ -207,7 +207,7 @@ defmodule ArangoXEcto.Migration do
     case Arangox.post(
            conn,
            ArangoXEcto.__build_connection_url__(
-             repo_or_conn,
+             conn,
              "index",
              Keyword.get(opts, :prefix),
              "?collection=#{collection_name}"


### PR DESCRIPTION
After migrating to 1.3.0, migrations don't works anymore.

Output coming from a migration: 
```
** (FunctionClauseError) no function clause matching in ArangoXEcto.get_repo_db/1    
    
    The following arguments were given to ArangoXEcto.get_repo_db/1:
    
        # 1
        nil
    
    Attempted function clauses (showing 1 out of 1):
    
        defp get_repo_db(repo) when not (repo == nil)
    
    (arangox_ecto 1.3.0) lib/arangox_ecto.ex:1251: ArangoXEcto.get_repo_db/1
    (arangox_ecto 1.3.0) lib/arangox_ecto.ex:943: ArangoXEcto.__build_connection_url__/4
    (arangox_ecto 1.3.0) lib/arangox_ecto/migration.ex:182: ArangoXEcto.Migration.create/2
    (arangox_ecto 1.3.0) lib/mix/tasks/ecto.migrate.arango.ex:73: anonymous fn/2 in Mix.Tasks.Ecto.Migrate.Arango.maybe_up_migrations/2
    (elixir 1.14.3) lib/enum.ex:975: Enum."-each/2-lists^foreach/1-0-"/2
    (mix 1.14.3) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (mix 1.14.3) lib/mix/cli.ex:84: Mix.CLI.run_task/2
```

The wrong variable was passed to `ArangoXEcto.__build_connection_url__`.

This PR correct this problem